### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 description = "A Twitch stream indicator for Linux with Wayland support"
 license = "GPL-3.0"
 authors = ["Fredrik Storm <fredrik@fldc.se>"]
-homepage = "https://github.com/fldc/twitch-indicator"
+repository = "https://github.com/fldc/twitch-indicator"
 readme = "README.md"
 documentation = "https://github.com/fldc/twitch-indicator/blob/master/README.md"
 


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/104